### PR TITLE
refactor: centralize error messages

### DIFF
--- a/lib/actions/signin.ts
+++ b/lib/actions/signin.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { ROUTES } from "@/lib/constants/routes";
+import { ERRORS } from "@/lib/constants/errors";
 import { getUser } from "@/lib/db-queries/user";
 import { connectDB } from "@/lib/mongodb";
 import { cookies } from "next/headers";
@@ -28,7 +29,7 @@ export const signin = async (
   if (!validatedFields.success) {
     return {
       fieldErrors: validatedFields.error.flatten().fieldErrors,
-      message: "Invalid data. Failed to Sign In.",
+      message: ERRORS.GENERAL.INVALID_DATA,
     };
   }
 
@@ -39,11 +40,11 @@ export const signin = async (
     await connectDB();
     const existingUser = await getUser({ email });
     if (!existingUser) {
-      return { error: "Wrong Email" };
+      return { error: ERRORS.AUTH.INVALID_CREDENTIALS };
     }
     const isValid = await existingUser.comparePassword(password);
     if (!isValid) {
-      return { error: "Wrong Password" };
+      return { error: ERRORS.AUTH.INVALID_CREDENTIALS };
     }
     cookieStore.set("userId", String(existingUser._id), {
       httpOnly: true,
@@ -53,7 +54,7 @@ export const signin = async (
     });
   } catch (error) {
     console.log(error);
-    return { message: "Database Error: Failed to Sign In." };
+    return { message: ERRORS.GENERAL.DATABASE };
   }
 
   const locale = cookieStore.get("locale")?.value;

--- a/lib/actions/signup.ts
+++ b/lib/actions/signup.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { ROUTES } from "@/lib/constants/routes";
+import { ERRORS } from "@/lib/constants/errors";
 import { getUser } from "@/lib/db-queries/user";
 import { connectDB } from "@/lib/mongodb";
 import User from "@/models/User";
@@ -30,7 +31,7 @@ export const signup = async (
   if (!validatedFields.success) {
     return {
       fieldErrors: validatedFields.error.flatten().fieldErrors,
-      message: "Invalid data. Failed to Create User.",
+      message: ERRORS.GENERAL.INVALID_DATA,
     };
   }
 
@@ -41,7 +42,7 @@ export const signup = async (
     await connectDB();
     const userFound = await getUser({ email });
     if (userFound) {
-      return { error: "Email already exists!" };
+      return { error: ERRORS.AUTH.EMAIL_EXISTS };
     }
     const username = email.split("@")[0];
     const publicSlug = await generateUniqueSlug(username);
@@ -55,7 +56,7 @@ export const signup = async (
     await newUser.save();
   } catch (error) {
     console.log(error);
-    return { message: "Database Error: Failed to Create User." };
+    return { message: ERRORS.GENERAL.DATABASE };
   }
   const locale = cookieStore.get("locale")?.value;
   redirect(locale ? `/${locale}${ROUTES.AUTH.SIGNIN}` : ROUTES.AUTH.SIGNIN);

--- a/lib/actions/updateProfile.ts
+++ b/lib/actions/updateProfile.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { ROUTES } from "@/lib/constants/routes";
+import { ERRORS } from "@/lib/constants/errors";
 import { connectDB } from "@/lib/mongodb";
 import { updateProfileSchema } from "@/lib/schemas/user.schema";
 import User from "@/models/User";
@@ -32,7 +33,7 @@ export async function updateProfile(
   if (!validatedFields.success) {
     return {
       fieldErrors: validatedFields.error.flatten().fieldErrors,
-      message: "Invalid data. Failed to update profile.",
+      message: ERRORS.GENERAL.INVALID_DATA,
     };
   }
 
@@ -41,7 +42,7 @@ export async function updateProfile(
   const userId = cookieStore.get("userId")?.value;
 
   if (!userId) {
-    return { error: "Not authenticated." };
+    return { error: ERRORS.AUTH.NOT_AUTHENTICATED };
   }
 
   try {
@@ -49,13 +50,13 @@ export async function updateProfile(
     const user = await User.findById(userId);
 
     if (!user) {
-      return { error: "User not found" };
+      return { error: ERRORS.AUTH.USER_NOT_FOUND };
     }
 
     const isValidPassword = await user.comparePassword(currentPassword);
 
     if (!isValidPassword) {
-      return { error: "Current password is incorrect." };
+      return { error: ERRORS.AUTH.PASSWORD_INCORRECT };
     }
 
     user.username = username;
@@ -66,7 +67,7 @@ export async function updateProfile(
     await user.save();
   } catch (error) {
     console.error(error);
-    return { message: "Database Error: Failed to update profile." };
+    return { message: ERRORS.GENERAL.DATABASE };
   }
 
   const locale = cookieStore.get("locale")?.value || "";

--- a/lib/constants/errors.ts
+++ b/lib/constants/errors.ts
@@ -1,0 +1,26 @@
+export const ERRORS = {
+  GENERAL: {
+    INVALID_DATA: "Invalid data. Please check your inputs.",
+    DATABASE: "Database error. Please try again later.",
+    FIELD_REQUIRED: "This field is required.",
+  },
+  AUTH: {
+    INVALID_CREDENTIALS: "Invalid email or password.",
+    EMAIL_EXISTS: "Email already exists.",
+    NOT_AUTHENTICATED: "Not authenticated.",
+    USER_NOT_FOUND: "User not found.",
+    PASSWORD_INCORRECT: "Current password is incorrect.",
+  },
+  USER: {
+    PASSWORDS_MISMATCH: "Passwords do not match.",
+    USERNAME_LENGTH: "Username must be between 2 and 30 characters.",
+    EMAIL_FORMAT: "Email format is incorrect.",
+    PASSWORD_COMPLEXITY:
+      "The password must contain 6 or more characters with at least one letter (a-z) and one number (0-9).",
+  },
+  FILE: {
+    REQUIRED: "File is required.",
+    TYPE: "Must be a JPG, PNG, or WEBP image.",
+    SIZE: "Max file size is 5MB.",
+  },
+} as const;

--- a/lib/schemas/user.schema.ts
+++ b/lib/schemas/user.schema.ts
@@ -1,4 +1,5 @@
 import { EMAIL_REGEX, PASSWORD_REGEX } from "@/lib/constants/regex";
+import { ERRORS } from "@/lib/constants/errors";
 import { z } from "zod";
 
 const MAX_FILE_SIZE = 50_000_00;
@@ -14,25 +15,25 @@ export const userSchema = z.object({
   username: z
     .string()
     .min(2, {
-      message: "Username must be at least 2 characters.",
+      message: ERRORS.USER.USERNAME_LENGTH,
     })
     .max(30, {
-      message: "Username must not be longer than 30 characters.",
+      message: ERRORS.USER.USERNAME_LENGTH,
     }),
   image: z
     .custom<File>()
-    .refine((file) => file?.name.length > 0, "File is required.")
+    .refine((file) => file?.name.length > 0, ERRORS.FILE.REQUIRED)
     .refine(
       (file) => ACCEPTED_IMAGE_TYPES.includes(file?.type),
-      "Must be a JPG, PNG, or WEBP image.",
+      ERRORS.FILE.TYPE,
     )
-    .refine((file) => file?.size <= MAX_FILE_SIZE, `Max file size is 5MB.`),
-  email: z.string().regex(EMAIL_REGEX, "Email format is incorrect."),
+    .refine((file) => file?.size <= MAX_FILE_SIZE, ERRORS.FILE.SIZE),
+  email: z.string().regex(EMAIL_REGEX, ERRORS.USER.EMAIL_FORMAT),
   password: z
     .string()
     .regex(
       PASSWORD_REGEX,
-      "The password must contain 6 or more characters with at least one letter (a-z) and one number (0-9).",
+      ERRORS.USER.PASSWORD_COMPLEXITY,
     ),
 });
 
@@ -47,7 +48,7 @@ export const signUpUserSchema = userSchema
   })
   .refine((data) => data.password === data.confirm, {
     path: ["confirm"],
-    message: "Passwords do not match.",
+    message: ERRORS.USER.PASSWORDS_MISMATCH,
   });
 
 export const signInUserSchema = userSchema.omit({
@@ -61,21 +62,21 @@ export const updateProfileSchema = z
     username: z
       .string()
       .min(2, {
-        message: "Username must be at least 2 characters.",
+        message: ERRORS.USER.USERNAME_LENGTH,
       })
       .max(30, {
-        message: "Username must not be longer than 30 characters.",
+        message: ERRORS.USER.USERNAME_LENGTH,
       }),
     currentPassword: z
       .string()
-      .min(1, { message: "Current password is required." }),
+      .min(1, { message: ERRORS.GENERAL.FIELD_REQUIRED }),
     newPassword: z
       .union([
         z
           .string()
           .regex(
             PASSWORD_REGEX,
-            "The password must contain 6 or more characters with at least one letter (a-z) and one number (0-9).",
+            ERRORS.USER.PASSWORD_COMPLEXITY,
           ),
         z.literal(""),
       ])
@@ -90,7 +91,7 @@ export const updateProfileSchema = z
       if (!hasNewPassword) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          message: "New password is required.",
+          message: ERRORS.GENERAL.FIELD_REQUIRED,
           path: ["newPassword"],
         });
       }
@@ -98,7 +99,7 @@ export const updateProfileSchema = z
       if (!hasConfirm) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          message: "Confirm password is required.",
+          message: ERRORS.GENERAL.FIELD_REQUIRED,
           path: ["confirm"],
         });
       }
@@ -106,7 +107,7 @@ export const updateProfileSchema = z
       if (hasNewPassword && hasConfirm && data.newPassword !== data.confirm) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          message: "Passwords do not match.",
+          message: ERRORS.USER.PASSWORDS_MISMATCH,
           path: ["confirm"],
         });
       }


### PR DESCRIPTION
## Summary
- group error messages into domain-based categories for easier lookup
- update validation schemas and auth actions to use grouped error messages

## Testing
- `npm run lint`